### PR TITLE
Updated libGeoIP to use new os.Open args

### DIFF
--- a/libgeo.go
+++ b/libgeo.go
@@ -151,7 +151,7 @@ func Load(filename string) (gi *GeoIP, err os.Error) {
 	if err != nil {
 		return
 	}
-	dbFile, err := os.Open(filename, os.O_RDONLY, OPEN_PERM)
+	dbFile, err := os.Open(filename)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
I ran gofix on libgeo.go to update for the new os.Open arguments.  Thanks for the code.
