### PR TITLE
Adding method GetDatabaseType to determine the database type.

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -26,6 +26,8 @@ func main() {
 		return
 	}
 
+	fmt.Printf("Database Type: %s\n", gi.GetDatabaseType())
+
 	// Lookup the IP and display the details if country is found
 	loc := gi.GetLocationByIP(ipAddr)
 	if loc != nil {


### PR DESCRIPTION
The `GetDatabaseType` method is useful for applications that need validate that a city database was loaded (i.e. for apps that require latitude and longitude).
