### PR TITLE
Allow loading from mem

### DIFF
--- a/libgeo.go
+++ b/libgeo.go
@@ -32,7 +32,7 @@ package libgeo
 // Dependencies
 import (
 	"errors"
-	"os"
+	"io/ioutil"
 )
 
 // Globals (const arrays that will be initialized inside init())
@@ -144,24 +144,9 @@ type Location struct {
 	Longitude   float32
 }
 
-// Load the database file in memory, detect the db format and setup the GeoIP struct
-func Load(filename string) (gi *GeoIP, err error) {
-	// Try to open the requested file
-	dbInfo, err := os.Lstat(filename)
-	if err != nil {
-		return
-	}
-	dbFile, err := os.Open(filename)
-	if err != nil {
-		return
-	}
-
-	// Copy the db into memory
+func LoadData(data []byte) (gi *GeoIP, err error) {
 	gi = new(GeoIP)
-	gi.data = make([]byte, dbInfo.Size())
-	dbFile.Read(gi.data)
-	dbFile.Close()
-
+	gi.data = data
 	// Check the database type
 	gi.dbType = dbCountryEdition           // Default the database to country edition
 	gi.databaseSegment = countryBegin      // Default to country DB
@@ -198,6 +183,16 @@ func Load(filename string) (gi *GeoIP, err error) {
 	}
 
 	return
+}
+
+// Load the database file in memory, detect the db format and setup the GeoIP struct
+func Load(filename string) (gi *GeoIP, err error) {
+	// Copy the db into memory
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.New(err.Error())
+	}
+	return LoadData(data)
 }
 
 // Lookup by IP address and return location

--- a/libgeo_test.go
+++ b/libgeo_test.go
@@ -1,0 +1,78 @@
+package libgeo
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+const (
+	GEO_IP_FILE_LOC = "GeoLiteCity.dat"
+)
+
+func TestNoFileExist(t *testing.T) {
+	if _, err := Load("does/not/exist"); err == nil {
+		t.Fatalf("expected err when not such file exists")
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	if len(GEO_IP_FILE_LOC) == 0 {
+		t.Fatalf("please fill out the path for GEO_IP_FILE_LOC")
+	}
+	if _, err := Load(GEO_IP_FILE_LOC); err != nil {
+		t.Fatalf(err.Error())
+	}
+}
+
+func TestReadFromMem(t *testing.T) {
+	if len(GEO_IP_FILE_LOC) == 0 {
+		t.Fatalf("please fill out the path for GEO_IP_FILE_LOC")
+	}
+	if data, err := ioutil.ReadFile(GEO_IP_FILE_LOC); err != nil {
+		t.Fatalf(err.Error())
+	} else {
+		if _, err := LoadData(data); err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+}
+
+func TestBasicFromFile(t *testing.T) {
+	if geoip, err := Load(GEO_IP_FILE_LOC); err != nil {
+		t.Fatalf(err.Error())
+	} else {
+		ip := "72.229.28.185"
+		loc := geoip.GetLocationByIP(ip)
+		if loc.City != "New York" {
+			t.Fatalf("expected city to equal New York but got %s instead", loc.City)
+		}
+		if loc.CountryCode != "US" {
+			t.Fatalf("expected country code to equal US but got %s instead", loc.CountryCode)
+		}
+		if loc.CountryName != "United States" {
+			t.Fatalf("expected country name to equal United States but got %s instead", loc.CountryName)
+		}
+	}
+}
+
+func TestBasicFromMem(t *testing.T) {
+	if data, err := ioutil.ReadFile(GEO_IP_FILE_LOC); err != nil {
+		t.Fatalf(err.Error())
+	} else {
+		if geoip, err := LoadData(data); err != nil {
+			t.Fatalf(err.Error())
+		} else {
+			ip := "72.229.28.185"
+			loc := geoip.GetLocationByIP(ip)
+			if loc.City != "New York" {
+				t.Fatalf("expected city to equal New York but got %s instead", loc.City)
+			}
+			if loc.CountryCode != "US" {
+				t.Fatalf("expected country code to equal US but got %s instead", loc.CountryCode)
+			}
+			if loc.CountryName != "United States" {
+				t.Fatalf("expected country name to equal United States but got %s instead", loc.CountryName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added the option to load the `geoip` data file directly from a `[]byte` (for cases when you download the file or something like that and you don't have it physically available on a filesystem).

I also took the time to add some testing for various scenarios. In order for tests to pass one needs to set the `const GEO_IP_FILE_LOC` variable in the testing file. 
